### PR TITLE
Refactored error handling

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+- "segments/context_tokenizer.py"
+- "segments/scripts/context_tokenizer.py"
+

--- a/segments/errors.py
+++ b/segments/errors.py
@@ -1,0 +1,23 @@
+# coding: utf8
+"""
+Default implementations for error handlers
+"""
+from __future__ import unicode_literals, print_function, division
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def strict(c):
+    log.debug('invalid grapheme: {0}'.format(c))
+    raise ValueError('invalid grapheme')
+
+
+def replace(c):
+    log.debug('replacing grapheme: {0}'.format(c))
+    return '\ufffd'
+
+
+def ignore(c):
+    log.debug('ignoring grapheme: {0}'.format(c))
+    return ''

--- a/segments/tests/test_tokenizer.py
+++ b/segments/tests/test_tokenizer.py
@@ -44,6 +44,19 @@ class TokenizerTestCase(unittest.TestCase):
     def setUp(self):
         self.t = Tokenizer(_test_path('test.prf'))
 
+    def test_errors(self):
+        t = Tokenizer(_test_path('test.prf'), errors_replace=lambda c: '<{0}>'.format(c))
+        self.assertEqual(t('habe'), '<i> a b <e>')
+
+        with self.assertRaises(ValueError):
+            t('habe', errors='strict')
+
+        self.assertEqual(t('habe', errors='ignore'), 'a b')
+
+    def test_ipa(self):
+        t = Tokenizer()
+        self.assertEqual(t('\u02b0ello', ipa=True), '\u02b0e l l o')
+
     def test_tokenize_with_profile(self):
         self.assertEqual(self.t('aa'), 'b')
 
@@ -101,4 +114,8 @@ class TokenizerTestCase(unittest.TestCase):
 
     def test_find_missing_characters(self):
         result = self.t.find_missing_characters("aa b ch on n - ih x y z")
+        self.assertEqual(result, "aa b ch on n - ih \ufffd \ufffd \ufffd")
+
+        t = Tokenizer(_test_path('test.prf'), errors_replace=lambda c: '?')
+        result = t.find_missing_characters("aa b ch on n - ih x y z")
         self.assertEqual(result, "aa b ch on n - ih ? ? ?")


### PR DESCRIPTION
As outlined in #7, handling of tokenization errors is refactored to follow
the way [python handles encoding/decoding errors](https://docs.python.org/3/library/codecs.html#error-handlers).

`Tokenizer.__call__` gains a keyword argument `errors` which accepts a string,
specifying the desired behaviour, defaulting to `'replace'`. Following the
python practice, `U+FFFD REPLACEMENT CHARACTER` is used as default to signal
replacement.

closes #7